### PR TITLE
Use packaging.Version for version handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,3 @@ testpaths = ["tests"]
 python_version = "3.10"
 strict = true
 warn_return_any = false
-
-[tool.bandit]
-exclude_dirs = ["tests"]
-skips = ["B101"]         # Skip assert_used test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "harupy", email = "17039389+harupy@users.noreply.github.com" },
 ]
 requires-python = ">=3.10"
-dependencies = ["httpx>=0.28.1", "typing-extensions>=4.14.1"]
+dependencies = ["httpx>=0.28.1", "typing-extensions>=4.14.1", "packaging>=24.0"]
 
 [project.scripts]
 pypi = "pypi:main"
@@ -47,4 +47,4 @@ warn_return_any = false
 
 [tool.bandit]
 exclude_dirs = ["tests"]
-skips = ["B101"]  # Skip assert_used test
+skips = ["B101"]         # Skip assert_used test

--- a/src/pypi/types.py
+++ b/src/pypi/types.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Any
 
+from packaging.version import Version
 from typing_extensions import Self
 
 
@@ -46,7 +47,7 @@ class ProjectInfo:
     requires_dist: list[str]
     requires_python: str
     summary: str
-    version: str
+    version: Version
     yanked: bool
     yanked_reason: str | None
 
@@ -78,7 +79,7 @@ class ProjectInfo:
             requires_dist=data.get("requires_dist", []),
             requires_python=data["requires_python"],
             summary=data["summary"],
-            version=data["version"],
+            version=Version(data["version"]),
             yanked=data["yanked"],
             yanked_reason=data["yanked_reason"],
         )

--- a/tests/clients/test_pypi_client.py
+++ b/tests/clients/test_pypi_client.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 import httpx
 import pytest
+from packaging.version import Version
 from pytest_httpx import HTTPXMock
 
 from pypi.clients import PyPIClient
@@ -57,7 +58,7 @@ async def test_get_project_requests(
 
     assert isinstance(result, ProjectResponse)
     assert result.info.name == "requests"
-    assert result.info.version == "2.32.4"
+    assert result.info.version == Version("2.32.4")
     assert result.info.author == "Kenneth Reitz"
     assert result.info.author_email == "me@kennethreitz.org"
     assert result.info.summary == "Python HTTP for Humans."
@@ -107,7 +108,7 @@ async def test_get_project_version_requests(
 
     assert isinstance(result, ProjectResponse)
     assert result.info.name == "requests"
-    assert result.info.version == "2.31.0"
+    assert result.info.version == Version("2.31.0")
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -271,6 +271,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "packaging" },
     { name = "typing-extensions" },
 ]
 
@@ -287,6 +288,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "packaging", specifier = ">=24.0" },
     { name = "typing-extensions", specifier = ">=4.14.1" },
 ]
 


### PR DESCRIPTION
## Summary
- Add `packaging` dependency to enable proper version handling
- Update `ProjectInfo.version` to use `packaging.version.Version` instead of string
- Fix test assertions to compare `Version` objects

## Benefits
- Proper version comparison and normalization according to PEP 440
- Better type safety for version handling
- Enables advanced version operations (parsing, comparison, etc.)

## Test plan
- [x] All existing tests pass
- [x] Type checking passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)