### PR TITLE
Add Vulnerability dataclass for type safety

### DIFF
--- a/src/pypi/types.py
+++ b/src/pypi/types.py
@@ -143,12 +143,37 @@ class ReleaseFile:
 
 
 @dataclass
+class Vulnerability:
+    aliases: list[str]
+    details: str
+    summary: str | None
+    fixed_in: list[str]
+    id: str
+    link: str
+    source: str
+    withdrawn: str | None
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        return cls(
+            aliases=data["aliases"],
+            details=data["details"],
+            summary=data.get("summary"),
+            fixed_in=data["fixed_in"],
+            id=data["id"],
+            link=data["link"],
+            source=data["source"],
+            withdrawn=data["withdrawn"],
+        )
+
+
+@dataclass
 class ProjectResponse:
     info: ProjectInfo
     last_serial: int
     releases: dict[str, list[ReleaseFile]]
     urls: list[ReleaseFile]
-    vulnerabilities: list[Any]
+    vulnerabilities: list[Vulnerability]
 
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> Self:
@@ -169,5 +194,7 @@ class ProjectResponse:
             last_serial=data["last_serial"],
             releases=releases,
             urls=[ReleaseFile.from_json(f) for f in data["urls"]],
-            vulnerabilities=data.get("vulnerabilities", []),
+            vulnerabilities=[
+                Vulnerability.from_json(vuln) for vuln in data.get("vulnerabilities", [])
+            ],
         )


### PR DESCRIPTION
## Summary
- Create `Vulnerability` dataclass with all security advisory fields
- Update `ProjectResponse` to use `list[Vulnerability]` instead of `list[Any]`
- Add proper JSON parsing for vulnerability data

## Benefits
- Better type safety for security vulnerability handling
- Structured access to vulnerability information (CVE aliases, details, fixed versions, etc.)
- Enables proper IDE support and autocompletion for vulnerability fields
- Consistent with other dataclass patterns in the codebase

## Changes
- New `Vulnerability` dataclass with fields: `aliases`, `details`, `summary`, `fixed_in`, `id`, `link`, `source`, `withdrawn`
- Updated `ProjectResponse.vulnerabilities` field type from `list[Any]` to `list[Vulnerability]`
- Added `Vulnerability.from_json()` class method for proper parsing

## Test plan
- [x] All existing tests pass
- [x] Type checking passes
- [x] Linting passes
- [x] Vulnerability parsing verified with existing test fixtures

🤖 Generated with [Claude Code](https://claude.ai/code)